### PR TITLE
Add Korean comments across trading modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# cPythonTest
+# Trading Framework
+
+This project provides a skeleton for an automated stock trading system using
+Python and Cython for performance. Market data is fetched via REST APIs, and the
+processing pipeline is structured as follows:
+
+1. **Data Fetcher** – Retrieves raw market data from an API.
+2. **Preprocessor** – Parses JSON or XML data into Python objects.
+3. **Analysis Modules** – Cython modules performing technical analysis.
+4. **Aggregator** – Collects results from analysis modules.
+5. **Decision Maker** – Determines buy/sell/hold decisions.
+6. **Trade Executor** – Executes trades (stub for brokerage integration).
+
+Cython modules can be built using:
+
+```bash
+pip install cython
+python setup.py build_ext --inplace
+```
+
+Run the example:
+
+```bash
+python -m trading.main
+```
+
+The example fetches data from a REST endpoint. If the request fails, mock price
+data is used instead. Analysis results are aggregated and a trade decision is
+printed to stdout.

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,17 @@
+from setuptools import setup
+from Cython.Build import cythonize
+
+extensions = [
+    'trading/analysis_base.pyx',
+    'trading/analysis_module1.pyx',
+    'trading/analysis_module2.pyx',
+    'trading/analysis_module3.pyx',
+    'trading/aggregator.pyx',
+    'trading/decision_maker.pyx',
+]
+
+setup(
+    name='trading',
+    ext_modules=cythonize(extensions, language_level=3),
+    zip_safe=False,
+)

--- a/trading/__init__.py
+++ b/trading/__init__.py
@@ -1,0 +1,13 @@
+"""자동 매매 프레임워크 패키지"""
+
+__all__ = [
+    'data_fetcher',
+    'preprocessor',
+    'trade_executor',
+    'analysis_module1',
+    'analysis_module2',
+    'analysis_module3',
+    'aggregator',
+    'decision_maker',
+    'main',
+]

--- a/trading/aggregator.pyx
+++ b/trading/aggregator.pyx
@@ -1,0 +1,21 @@
+# cython: language_level=3
+# 여러 분석 모듈에서 반환된 결과를 한 곳에 모으는 집계기
+# This Cython module collects results from analysis modules for fast aggregation.
+from .analysis_base cimport AnalysisModule
+
+cdef class Aggregator:
+    """여러 분석 모듈의 결과를 합산하는 클래스"""
+
+    cdef list modules
+
+    def __init__(self, modules):
+        # 모듈 리스트를 보관한다
+        self.modules = modules
+
+    cpdef dict run(self, object data):
+        """모든 분석 모듈을 실행하여 결과를 합친다"""
+        cdef dict result = {}
+        # 각 모듈의 analyze 메서드를 호출하고 결과를 병합한다
+        for module in self.modules:
+            result.update(module.analyze(data))
+        return result

--- a/trading/analysis_base.pxd
+++ b/trading/analysis_base.pxd
@@ -1,0 +1,4 @@
+# Cython 확장 모듈에서 상속받을 분석 모듈 인터페이스 정의
+cdef class AnalysisModule:
+    # 데이터를 분석하여 dict 형태로 결과를 반환해야 한다
+    cpdef dict analyze(self, object data)

--- a/trading/analysis_base.pyx
+++ b/trading/analysis_base.pyx
@@ -1,0 +1,9 @@
+# cython: language_level=3
+# 분석 모듈들이 상속받을 기본 Cython 클래스
+
+cdef class AnalysisModule:
+    """Cython 기반 분석 모듈의 추상 클래스"""
+
+    cpdef dict analyze(self, object data):
+        """데이터를 받아 분석 결과를 dict 로 반환"""
+        raise NotImplementedError()

--- a/trading/analysis_module1.pyx
+++ b/trading/analysis_module1.pyx
@@ -1,0 +1,25 @@
+# cython: language_level=3
+# 단순 이동 평균(SMA)을 계산하는 예제 분석 모듈
+from .analysis_base cimport AnalysisModule
+
+cdef class SMAAnalysis(AnalysisModule):
+    """단순 이동 평균을 계산"""
+
+    cdef int window
+
+    def __init__(self, int window=5):
+        # 평균을 계산할 기간(윈도우) 설정
+        self.window = window
+
+    cpdef dict analyze(self, object data):
+        """가격 리스트를 받아 SMA 값을 계산"""
+        cdef list prices = data['prices']
+        if len(prices) < self.window:
+            # 데이터가 부족하면 None 반환
+            return {'sma': None}
+        cdef double avg = 0
+        # 최근 window 개의 가격을 더한 후 평균을 구한다
+        for price in prices[-self.window:]:
+            avg += price
+        avg /= self.window
+        return {'sma': avg}

--- a/trading/analysis_module2.pyx
+++ b/trading/analysis_module2.pyx
@@ -1,0 +1,24 @@
+# cython: language_level=3
+# 가격 변동 비율(ROC)을 계산하는 모듈
+from .analysis_base cimport AnalysisModule
+
+cdef class ROCAnalysis(AnalysisModule):
+    """일정 기간 동안의 가격 변화율 계산"""
+
+    cdef int period
+
+    def __init__(self, int period=5):
+        # 변화율을 계산할 기준 기간
+        self.period = period
+
+    cpdef dict analyze(self, object data):
+        """가격 리스트로부터 ROC 값을 계산"""
+        cdef list prices = data['prices']
+        cdef int n = len(prices)
+        if n <= self.period:
+            # 과거 데이터가 충분하지 않을 경우 None 반환
+            return {'roc': None}
+        cdef double old_price = prices[n - self.period - 1]
+        cdef double new_price = prices[-1]
+        cdef double roc = ((new_price - old_price) / old_price) * 100
+        return {'roc': roc}

--- a/trading/analysis_module3.pyx
+++ b/trading/analysis_module3.pyx
@@ -1,0 +1,22 @@
+# cython: language_level=3
+# 모멘텀 값을 계산하는 분석 모듈
+from .analysis_base cimport AnalysisModule
+
+cdef class MomentumAnalysis(AnalysisModule):
+    """모멘텀 지표 계산"""
+
+    cdef int period
+
+    def __init__(self, int period=10):
+        # 모멘텀을 계산하기 위한 기간
+        self.period = period
+
+    cpdef dict analyze(self, object data):
+        """주어진 가격 데이터로 모멘텀을 계산"""
+        cdef list prices = data['prices']
+        cdef int n = len(prices)
+        if n <= self.period:
+            # 계산에 필요한 데이터가 부족한 경우
+            return {'momentum': None}
+        cdef double momentum = prices[-1] - prices[n - self.period - 1]
+        return {'momentum': momentum}

--- a/trading/data_fetcher.py
+++ b/trading/data_fetcher.py
@@ -1,0 +1,23 @@
+from abc import ABC, abstractmethod
+import requests
+
+class DataFetcher(ABC):
+    """시장 데이터를 가져오는 추상 베이스 클래스"""
+
+    @abstractmethod
+    def fetch(self):
+        """원격 소스에서 원시 데이터를 가져온다"""
+        pass
+
+class RestAPIFetcher(DataFetcher):
+    """REST API에서 데이터를 가져오는 구현체"""
+
+    def __init__(self, url: str):
+        # 호출할 API 주소
+        self.url = url
+
+    def fetch(self):
+        """실제 HTTP GET 요청을 보내어 데이터 획득"""
+        response = requests.get(self.url)
+        response.raise_for_status()
+        return response.text

--- a/trading/decision_maker.pyx
+++ b/trading/decision_maker.pyx
@@ -1,0 +1,26 @@
+# cython: language_level=3
+# 집계된 분석 결과를 기반으로 매매 여부를 판단하는 모듈
+
+cdef class DecisionMaker:
+    """분석 결과 합산 점수로 매수/매도/보유를 결정"""
+
+    cdef double buy_threshold
+    cdef double sell_threshold
+
+    def __init__(self, double buy_threshold=0.5, double sell_threshold=-0.5):
+        # 매수/매도 판정을 위한 임계값
+        self.buy_threshold = buy_threshold
+        self.sell_threshold = sell_threshold
+
+    cpdef str decide(self, dict aggregated):
+        """집계된 값을 이용해 매매 결정을 내린다"""
+        cdef double score = 0
+        # None 이 아닌 모든 값들을 합산하여 점수를 계산
+        for value in aggregated.values():
+            if value is not None:
+                score += value
+        if score > self.buy_threshold:
+            return 'BUY'
+        if score < self.sell_threshold:
+            return 'SELL'
+        return 'HOLD'

--- a/trading/main.py
+++ b/trading/main.py
@@ -1,0 +1,61 @@
+import random
+from typing import List
+
+# 간단한 예제용 메인 스크립트
+
+from .data_fetcher import RestAPIFetcher
+from .preprocessor import Preprocessor
+from .trade_executor import TradeExecutor
+
+# Cython modules
+from .analysis_module1 import SMAAnalysis
+from .analysis_module2 import ROCAnalysis
+from .analysis_module3 import MomentumAnalysis
+from .aggregator import Aggregator
+from .decision_maker import DecisionMaker
+
+
+def get_mock_prices(n=20):
+    """데모를 위한 가짜 가격 데이터 생성"""
+    prices = [random.uniform(100, 200) for _ in range(n)]
+    return {'prices': prices}
+
+
+def main(url: str):
+    """전체 흐름을 실행한다"""
+    fetcher = RestAPIFetcher(url)
+    preprocessor = Preprocessor()
+    executor = TradeExecutor()
+
+    # 실제 사용 시 네트워크에서 데이터를 가져옴
+    try:
+        raw = fetcher.fetch()
+        data = preprocessor.process(raw)
+    except Exception:
+        # 실패 시 임시 데이터 사용
+        data = get_mock_prices()
+
+    # 분석 모듈 목록 (필요 시 확장 가능)
+    modules: List = [
+        SMAAnalysis(5),
+        ROCAnalysis(5),
+        MomentumAnalysis(10),
+    ]
+
+    aggregator = Aggregator(modules)
+    decision_maker = DecisionMaker()
+
+    results = aggregator.run(data)
+    decision = decision_maker.decide(results)
+
+    if decision == 'BUY':
+        executor.buy('TEST', 1)
+    elif decision == 'SELL':
+        executor.sell('TEST', 1)
+    else:
+        print('Holding position')
+
+
+if __name__ == '__main__':
+    # Replace the URL with real endpoint
+    main('https://example.com/api/price')

--- a/trading/preprocessor.py
+++ b/trading/preprocessor.py
@@ -1,0 +1,16 @@
+import json
+from xml.etree import ElementTree
+
+class Preprocessor:
+    """JSON 또는 XML 데이터를 파싱하여 파이썬 객체로 변환"""
+
+    def process(self, text: str):
+        """문자열 형태의 데이터를 파싱"""
+        text = text.strip()
+        # JSON 형식
+        if text.startswith('{') or text.startswith('['):
+            return json.loads(text)
+        # XML 형식
+        if text.startswith('<'):
+            return ElementTree.fromstring(text)
+        raise ValueError('Unsupported data format')

--- a/trading/trade_executor.py
+++ b/trading/trade_executor.py
@@ -1,0 +1,10 @@
+class TradeExecutor:
+    """실제 브로커리지와 연동될 매매 실행기"""
+
+    def buy(self, symbol: str, amount: int):
+        """매수 주문 실행 (예시)"""
+        print(f"Buying {amount} of {symbol}")
+
+    def sell(self, symbol: str, amount: int):
+        """매도 주문 실행 (예시)"""
+        print(f"Selling {amount} of {symbol}")


### PR DESCRIPTION
## Summary
- add Korean explanations to each trading component
- include comments in Cython analysis modules and decision maker
- document code intent for fetcher, preprocessor, and executor

## Testing
- `python setup.py build_ext --inplace`
- `python -m trading.main`


------
https://chatgpt.com/codex/tasks/task_e_6865daa7bafc832ba8d1fbd7f21c80a7