### PR TITLE
Fix packaging instructions and add test

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@ The Cython sources are located under `trading/cy` so that compiled
 extensions remain separate from pure Python modules.
 
 Cython extensions can be compiled with `pip` since the project now uses a
-`pyproject.toml` based build. Install Cython and build the package in-place:
+`pyproject.toml` based build. Install Cython and build the package in-place
+before running the example:
 
 ```bash
-pip install cython
+pip install cython requests
 pip install -e .
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 description = "Cython-based trading framework"
 readme = "README.md"
 requires-python = ">=3.8"
+dependencies = ["requests"]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,15 @@
+import importlib
+
+
+def test_cython_modules_importable():
+    modules = [
+        'trading.cy.analysis_base',
+        'trading.cy.analysis_module1',
+        'trading.cy.analysis_module2',
+        'trading.cy.analysis_module3',
+        'trading.cy.aggregator',
+        'trading.cy.decision_maker',
+    ]
+    for mod in modules:
+        assert importlib.import_module(mod) is not None
+


### PR DESCRIPTION
## Summary
- document Cython build steps and dependencies
- declare requests runtime dependency
- add regression test ensuring Cython extensions import

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68660e3032dc832b83af9dfff253e48c